### PR TITLE
implement session state in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ or using yarn :
 	- [(Attribute) mute](#session-mute): `read-write`
 	- [(Attribute) volume](#session-volume): `read-write`
 	- [(Attribute) balance](#session-balance): `read-write`
+	- [(Attribute) state](#session-state): `readonly`
 
 4. [Data Structures](#4-Data-Structures)
 	- [Volume Scalar](#volumescalar)
@@ -199,6 +200,21 @@ const balance: VolumeBalance = session.balance;
 // sets right VolumeScalar to 1 and left VolumeScalar to .5
 // by default, left and right are equal to the VolumeScalar of the session
 session.balance = {right: 1, left: .5};
+```
+ 
+ - ### session state
+gets the [`AudioSessionState`](#audiosessionstate) for the session.
+
+```TypeScript
+// import ...
+
+// retrieving the state
+let session: AudioSession;
+const state: AudioSessionState = session.state;
+
+if (state === AudioSessionState.ACTIVE) {
+    // do something...
+}
 ```
 
 

--- a/cppsrc/linux/sound-mixer.cpp
+++ b/cppsrc/linux/sound-mixer.cpp
@@ -210,6 +210,7 @@ Napi::Value AudioSessionObject::New(Napi::Env env, void *data)
     Napi::ObjectWrap<AudioSessionObject>::Unwrap(result)->pSession = session;
     result.Set("name", session->description());
     result.Set("appName", session->appName());
+    result.Set("state", 1);
 
     return result;
 }

--- a/cppsrc/win/sound-mixer.cpp
+++ b/cppsrc/win/sound-mixer.cpp
@@ -328,7 +328,8 @@ Napi::Function AudioSessionObject::GetClass(Napi::Env env)
             InstanceAccessor<&AudioSessionObject::GetVolume,
                 &AudioSessionObject::SetVolume>("volume"),
             InstanceAccessor<&AudioSessionObject::GetChannelVolume,
-                &AudioSessionObject::SetChannelVolume>("balance")});
+                &AudioSessionObject::SetChannelVolume>("balance"),
+            InstanceAccessor<&AudioSessionObject::GetState>("state")});
 }
 
 Napi::Object AudioSessionObject::Init(Napi::Env env, Napi::Object exports)
@@ -350,7 +351,6 @@ Napi::Value AudioSessionObject::New(Napi::Env env, void *data)
     Napi::ObjectWrap<AudioSessionObject>::Unwrap(result)->pSession = session;
     result.Set("name", session->name());
     result.Set("appName", session->path());
-    result.Set("state", static_cast<int>(session->state()));
 
     return result;
 }
@@ -372,6 +372,12 @@ Napi::Value AudioSessionObject::GetMute(const Napi::CallbackInfo &info)
 {
     return Napi::Boolean::New(
         info.Env(), reinterpret_cast<AudioSession *>(pSession)->GetMute());
+}
+
+Napi::Value AudioSessionObject::GetState(const Napi::CallbackInfo &info)
+{
+    return Napi::Number::New(
+        info.Env(), static_cast<int>(reinterpret_cast<AudioSession *>(pSession)->state()));
 }
 
 void AudioSessionObject::SetMute(

--- a/cppsrc/win/sound-mixer.cpp
+++ b/cppsrc/win/sound-mixer.cpp
@@ -350,6 +350,7 @@ Napi::Value AudioSessionObject::New(Napi::Env env, void *data)
     Napi::ObjectWrap<AudioSessionObject>::Unwrap(result)->pSession = session;
     result.Set("name", session->name());
     result.Set("appName", session->path());
+    result.Set("state", static_cast<int>(session->state()));
 
     return result;
 }

--- a/cppsrc/win/sound-mixer.cpp
+++ b/cppsrc/win/sound-mixer.cpp
@@ -376,8 +376,8 @@ Napi::Value AudioSessionObject::GetMute(const Napi::CallbackInfo &info)
 
 Napi::Value AudioSessionObject::GetState(const Napi::CallbackInfo &info)
 {
-    return Napi::Number::New(
-        info.Env(), static_cast<int>(reinterpret_cast<AudioSession *>(pSession)->state()));
+    return Napi::Number::New(info.Env(),
+        static_cast<int>(reinterpret_cast<AudioSession *>(pSession)->state()));
 }
 
 void AudioSessionObject::SetMute(

--- a/cppsrc/win/sound-mixer.hpp
+++ b/cppsrc/win/sound-mixer.hpp
@@ -18,6 +18,7 @@ class AudioSessionObject : public Napi::ObjectWrap<AudioSessionObject> {
     AudioSessionObject(const Napi::CallbackInfo &info);
     virtual ~AudioSessionObject();
 
+    Napi::Value GetState(const Napi::CallbackInfo &info);
     Napi::Value GetVolume(const Napi::CallbackInfo &info);
     Napi::Value GetMute(const Napi::CallbackInfo &info);
     void SetVolume(const Napi::CallbackInfo &info, const Napi::Value &value);

--- a/src/sound-mixer.ts
+++ b/src/sound-mixer.ts
@@ -131,8 +131,8 @@ export declare class Device {
  *  @enum
  */
 export enum AudioSessionState {
-	ACTIVE = 0,
-	INACTIVE = 1,
+    INACTIVE = 0,
+	ACTIVE = 1,
 	EXPIRED = 2
 }
 
@@ -207,6 +207,12 @@ export declare class AudioSession {
      *  @readonly
      */
 	public readonly appName: string
+
+    /**
+     * The state of the {@link AudioSession}.
+     * @readonly
+     */
+	public readonly state: AudioSessionState
 }
 
 /**


### PR DESCRIPTION
I noticed that the library also returned unused streams on Windows. 
I was making an application that detects whenever a specific process is using the microphone. I used discord for testing. When joining a channel, it would create an audio session and stop using is when quitting. It does not destroy it untill the program gets closed.

This is why I was happy to see the AudioSessionState enum. But found out is was not implemented.
So I did it, at least for Windows. 
For linux, I assumed the limitation was not present and audio sources dissapear when unused. I cannot test this at the moment but my modification does not change previous functionality of this lib.

I also changed the backing values for the AudioSessionState enum to be in line with Windows API, in which inactive = 0, active = 1 and expired = 2. Since the enum was not referenced anywhere in the code, this API change should not break anything.

Please tell me if I did anything wrong ! I didn't touch any c++ in ten years 😅.