### PR TITLE
Check for null pointer dereference

### DIFF
--- a/cppsrc/win/win-sound-mixer.cpp
+++ b/cppsrc/win/win-sound-mixer.cpp
@@ -305,8 +305,12 @@ bool Device::Update()
         SafeRelease(&endpointVolume);
     }
 
-    device->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
+    HRESULT activateRes = device->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL,
         (LPVOID *)&endpointVolume);
+    if (activateRes != S_OK || endpointVolume == NULL)
+    {
+        return false;
+    }
 
     if (device_cb == NULL)
         device_cb = new SoundMixerAudioEndpointVolumeCallback(this);


### PR DESCRIPTION
Hi @m1dugh, since this issue is quite severe for our users I have already made a proposal to fix this problem. However I have NOT tested this at all since I am unable to reproduce this problem and don't have a development environment for your project. So could you verify that this fix is correctly implemented? Thank you in advance.

Change:
The result of Activate should be checked. It may return NULL as described in https://learn.microsoft.com/en-us/windows/win32/api/mmdeviceapi/nf-mmdeviceapi-immdevice-activate This will prevent a null pointer dereference when the Activate function fails. Fixes #42 and see https://github.com/m1dugh/native-sound-mixer/issues/42 for details.