### PR TITLE
Add more HRESULT checks to fix null pointer dereferences

### DIFF
--- a/cppsrc/win/win-sound-mixer.cpp
+++ b/cppsrc/win/win-sound-mixer.cpp
@@ -382,7 +382,8 @@ float Device::GetVolume()
 {
     float volume;
     HRESULT res = endpointVolume->GetMasterVolumeLevelScalar(&volume);
-    if (res != S_OK) {
+    if (res != S_OK)
+    {
         return 0.F;
     }
     return volume;
@@ -392,9 +393,11 @@ bool Device::GetMute()
 {
     BOOL mute;
     HRESULT res = endpointVolume->GetMute(&mute);
-    if (res != S_OK) {
-        // if we can't retrieve the GetMute state, there is probably something wrong with the audio endpoint 
-        // and the user can't hear it anyway, so just return true for the mute state.
+    if (res != S_OK)
+    {
+        // if we can't retrieve the GetMute state, there is probably something
+        // wrong with the audio endpoint and the user can't hear it anyway, so
+        // just return true for the mute state.
         return true;
     }
     return (bool)mute;
@@ -431,14 +434,18 @@ VolumeBalance Device::GetVolumeBalance()
         return result;
     }
     result.stereo = true;
-    HRESULT res1 = endpointVolume->GetChannelVolumeLevelScalar(RIGHT, &result.right);
-    if (res1 != S_OK) {
+    HRESULT res1
+        = endpointVolume->GetChannelVolumeLevelScalar(RIGHT, &result.right);
+    if (res1 != S_OK)
+    {
         result.right = 0.F; // revert right volume
         return result;
     }
 
-    HRESULT res2 = endpointVolume->GetChannelVolumeLevelScalar(LEFT, &result.left);
-    if (res2 != S_OK) {
+    HRESULT res2
+        = endpointVolume->GetChannelVolumeLevelScalar(LEFT, &result.left);
+    if (res2 != S_OK)
+    {
         result.left = 0.F; // revert left volume
         return result;
     }


### PR DESCRIPTION
Hello again!

Thanks again for this very useful project! After the merge of https://github.com/m1dugh/native-sound-mixer/issues/42, that issue went away, but new null pointer dereference issues appeared in our bug tracker. I had a look at it and found the following:

On multiple places, there is an interaction with `endpointVolume` and the function is expected to return something,  but the return value of `endpointVolume` is not checked. Therefore, undefined values may be returned. This PR adds return value checks with default values as return values for failing `endpointVolume` interactions. This should fix null pointer dereference issues.

For the record, here is the stack trace that I initially triaged:
```
EXCEPTION_ACCESS_VIOLATION_READ: Attempted to dereference null pointer.

0  win-sound-mixer.node +0xcc6a  0xcc6a
   r10 = 0xfffefa1f215        rbp = 0x0              
   r11 = 0xaa8a88282a288a22   rbx = 0x22517d328c8    
   r12 = 0x22517dfc2e0        rcx = 0x0              
   r13 = 0x8e1cffcbb8         rdi = 0x22517d32880    
   r14 = 0xf                  rdx = 0x7fff7d23b340   
   r15 = 0x0                  rip = 0x7fff7cffcc6a   
    r8 = 0x1                  rsi = 0x8e1cffca50     
    r9 = 0x1                  rsp = 0x8e1cffc9c0     
   rax = 0x80070000           
1  ntdll.dll +0x3dcb4            0x3dcb5
2  win-sound-mixer.node +0x10d7b 0x10d7c
3  win-sound-mixer.node +0xe386  0xe387
4  win-sound-mixer.node +0x733b  0x733c
```
Instruction with the issue: `mov     rax, [rcx]`. rcx is clearly NULL and therefore can't be dereferenced.

The stack trace points to the following lines of code: https://github.com/m1dugh/native-sound-mixer/blob/master/cppsrc/win/win-sound-mixer.cpp#L235-L236:
```
    _oldVolume = GetVolume();
    _oldMute = (BOOL)GetMute();
```

---

Please note that I still don't have a setup to compile and test this myself and therefore the code is NOT tested. @m1dugh can you have a look at it?

I was not able to reproduce the error myself, but maybe you can try disabling your audio card in the Windows settings to create a faulty audio device that may trigger these errors.